### PR TITLE
Add updateclientservice endpoint for updating client service dates

### DIFF
--- a/src/MindbodyREST/RESTEndpoint/Client/ClientRESTRequester.php
+++ b/src/MindbodyREST/RESTEndpoint/Client/ClientRESTRequester.php
@@ -10,6 +10,7 @@ use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\GET
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\GETCrossRegionalClientAssociationRequest;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\POSTAddClientRequest;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\POSTUpdateClientRequest;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\POSTUpdateClientServiceRequest;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request\POSTUpdateClientVisitRequest;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\GETClientPurchasesResponse;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\GETClientServicesResponse;
@@ -18,6 +19,7 @@ use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\GE
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\GETCrossRegionalClientAssociationResponse;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\POSTAddClientResponse;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\POSTUpdateClientResponse;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\POSTUpdateClientServiceResponse;
 use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\POSTUpdateClientVisitResponse;
 
 class ClientRESTRequester
@@ -58,6 +60,11 @@ class ClientRESTRequester
     public function updateClientVisit(POSTUpdateClientVisitRequest $request): POSTUpdateClientVisitResponse
     {
         return $this->restRequester->executeRequest($request, POSTUpdateClientVisitResponse::class);
+    }
+
+    public function updateClientService(POSTUpdateClientServiceRequest $request): POSTUpdateClientServiceResponse
+    {
+        return $this->restRequester->executeRequest($request, POSTUpdateClientServiceResponse::class);
     }
 
     public function postUpdateClient(POSTUpdateClientRequest $request): POSTUpdateClientResponse

--- a/src/MindbodyREST/RESTEndpoint/Client/Request/POSTUpdateClientServiceRequest.php
+++ b/src/MindbodyREST/RESTEndpoint/Client/Request/POSTUpdateClientServiceRequest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Request;
+
+use DateTimeImmutable;
+use JMS\Serializer\Annotation as Serializer;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Common\Model\RESTRequest;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Common\Model\UserStaffTokenRequiredInterface;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Common\Util\UserStaffTokenRequiredTrait;
+
+class POSTUpdateClientServiceRequest extends RESTRequest implements UserStaffTokenRequiredInterface
+{
+    use UserStaffTokenRequiredTrait;
+
+    #[Serializer\SerializedName('ActiveDate')]
+    #[Serializer\Type("DateTimeImmutable<'Y-m-d\\TH:i:s'>")]
+    #[Serializer\SkipWhenEmpty]
+    private ?DateTimeImmutable $activeDate = null;
+
+    #[Serializer\SerializedName('ExpirationDate')]
+    #[Serializer\Type("DateTimeImmutable<'Y-m-d\\TH:i:s'>")]
+    #[Serializer\SkipWhenEmpty]
+    private ?DateTimeImmutable $expirationDate = null;
+
+    #[Serializer\SerializedName('Count')]
+    #[Serializer\SkipWhenEmpty]
+    private ?int $count = null;
+
+    public function __construct(
+        #[Serializer\SerializedName('ServiceId')]
+        private readonly int $serviceId,
+    ) {
+    }
+
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+
+    public function getPath(): string
+    {
+        return 'client/updateclientservice';
+    }
+
+    public function getServiceId(): int
+    {
+        return $this->serviceId;
+    }
+
+    public function getActiveDate(): ?DateTimeImmutable
+    {
+        return $this->activeDate;
+    }
+
+    public function setActiveDate(DateTimeImmutable $activeDate): self
+    {
+        $this->activeDate = $activeDate;
+
+        return $this;
+    }
+
+    public function getExpirationDate(): ?DateTimeImmutable
+    {
+        return $this->expirationDate;
+    }
+
+    public function setExpirationDate(DateTimeImmutable $expirationDate): self
+    {
+        $this->expirationDate = $expirationDate;
+
+        return $this;
+    }
+
+    public function getCount(): ?int
+    {
+        return $this->count;
+    }
+
+    public function setCount(int $count): self
+    {
+        $this->count = $count;
+
+        return $this;
+    }
+}

--- a/src/MindbodyREST/RESTEndpoint/Client/Response/POSTUpdateClientServiceResponse.php
+++ b/src/MindbodyREST/RESTEndpoint/Client/Response/POSTUpdateClientServiceResponse.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response;
+
+use JMS\Serializer\Annotation as Serializer;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Client\Response\Model\ClientService;
+use MiguelAlcaino\MindbodyApiClient\MindbodyREST\RESTEndpoint\Common\Model\RESTResponse;
+
+class POSTUpdateClientServiceResponse extends RESTResponse
+{
+    public function __construct(
+        #[Serializer\SerializedName('ClientService')]
+        private readonly ClientService $clientService,
+    ) {
+    }
+
+    public function getClientService(): ClientService
+    {
+        return $this->clientService;
+    }
+}


### PR DESCRIPTION
Adds POSTUpdateClientServiceRequest/Response and the updateClientService method to ClientRESTRequester, enabling updates to ActiveDate, ExpirationDate, and Count on a client's pricing option via the Mindbody API.